### PR TITLE
feat: add AI reply suggestions

### DIFF
--- a/app/controllers/api/v1/accounts/conversations/ai_suggestions_controller.rb
+++ b/app/controllers/api/v1/accounts/conversations/ai_suggestions_controller.rb
@@ -1,0 +1,12 @@
+class Api::V1::Accounts::Conversations::AiSuggestionsController < Api::V1::Accounts::Conversations::BaseController
+  def create
+    if params[:selection]
+      Rails.logger.info("AI suggestion selected", conversation_id: @conversation.id, selection: params[:selection])
+      head :ok
+      return
+    end
+
+    suggestions = AiReplySuggestionService.new(@conversation).perform
+    render json: { suggestions: suggestions }
+  end
+end

--- a/app/controllers/api/v1/accounts_controller.rb
+++ b/app/controllers/api/v1/accounts_controller.rb
@@ -92,7 +92,14 @@ class Api::V1::AccountsController < Api::BaseController
   end
 
   def settings_params
-    params.permit(:auto_resolve_after, :auto_resolve_message, :auto_resolve_ignore_waiting, :audio_transcriptions, :auto_resolve_label)
+    params.permit(
+      :auto_resolve_after,
+      :auto_resolve_message,
+      :auto_resolve_ignore_waiting,
+      :audio_transcriptions,
+      :auto_resolve_label,
+      :ai_suggestions_enabled
+    )
   end
 
   def check_signup_enabled

--- a/app/javascript/dashboard/components/ChatInputWrap.vue
+++ b/app/javascript/dashboard/components/ChatInputWrap.vue
@@ -1,0 +1,73 @@
+<script setup>
+import { ref, computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useMapGetter } from 'dashboard/composables/store';
+import { useAI } from 'dashboard/composables/useAI';
+import axios from 'axios';
+
+const { t } = useI18n();
+const message = ref('');
+const suggestions = ref([]);
+const showSuggestions = ref(false);
+
+const currentChat = useMapGetter('getSelectedChat');
+const currentAccountId = useMapGetter('getCurrentAccountId');
+const { recordAnalytics } = useAI();
+
+const conversationId = computed(() => currentChat.value?.id);
+const accountId = computed(() => currentAccountId.value);
+
+const fetchSuggestions = async () => {
+  if (!conversationId.value) return;
+  const { data } = await axios.post(
+    `/api/v1/accounts/${accountId.value}/conversations/${conversationId.value}/ai_suggestions`
+  );
+  suggestions.value = data.suggestions || [];
+  showSuggestions.value = true;
+};
+
+const applySuggestion = (text, index) => {
+  message.value = text;
+  showSuggestions.value = false;
+  recordAnalytics('REPLY_SUGGESTION', { index });
+  axios.post(
+    `/api/v1/accounts/${accountId.value}/conversations/${conversationId.value}/ai_suggestions`,
+    { selection: index }
+  );
+};
+</script>
+
+<template>
+  <div class="space-y-2">
+    <textarea
+      v-model="message"
+      class="w-full border rounded p-2"
+      :placeholder="t('CONVERSATION.AI_SUGGESTIONS.PLACEHOLDER')"
+    />
+    <div class="flex gap-2">
+      <button
+        type="button"
+        class="px-2 py-1 bg-n-weak hover:bg-n-solid-1 rounded"
+        @click="fetchSuggestions"
+      >
+        {{ t('CONVERSATION.AI_SUGGESTIONS.BUTTON') }}
+      </button>
+    </div>
+    <div v-if="showSuggestions" class="border rounded p-2 space-y-1">
+      <p v-if="!suggestions.length" class="text-sm text-n-slate-11">
+        {{ t('CONVERSATION.AI_SUGGESTIONS.NO_SUGGESTIONS') }}
+      </p>
+      <ul v-else class="space-y-1">
+        <li v-for="(s, index) in suggestions" :key="index">
+          <button
+            type="button"
+            class="w-full text-left hover:bg-n-alpha-2 p-1 rounded"
+            @click="applySuggestion(s, index)"
+          >
+            {{ s }}
+          </button>
+        </li>
+      </ul>
+    </div>
+  </div>
+</template>

--- a/app/javascript/dashboard/i18n/locale/en/conversation.json
+++ b/app/javascript/dashboard/i18n/locale/en/conversation.json
@@ -44,6 +44,11 @@
     "UNKNOWN_FILE_TYPE": "Unknown File",
     "SAVE_CONTACT": "Save Contact",
     "NO_CONTENT": "No content to display",
+    "AI_SUGGESTIONS": {
+      "BUTTON": "AI Suggestion",
+      "PLACEHOLDER": "Type your message",
+      "NO_SUGGESTIONS": "No suggestions available"
+    },
     "SHARED_ATTACHMENT": {
       "CONTACT": "{sender} has shared a contact",
       "LOCATION": "{sender} has shared a location",

--- a/app/javascript/dashboard/i18n/locale/en/generalSettings.json
+++ b/app/javascript/dashboard/i18n/locale/en/generalSettings.json
@@ -104,6 +104,14 @@
           "ERROR": "Failed to update audio transcription setting"
         }
       },
+      "AI_SUGGESTIONS": {
+        "TITLE": "AI reply suggestions",
+        "NOTE": "Enable AI-generated reply suggestions for agents.",
+        "API": {
+          "SUCCESS": "AI suggestions setting updated",
+          "ERROR": "Failed to update AI suggestions setting"
+        }
+      },
       "AUTO_RESOLVE_DURATION": {
         "LABEL": "Inactivity duration for resolution",
         "HELP": "Duration after a conversation should auto resolve if there is no activity",

--- a/app/javascript/dashboard/routes/dashboard/settings/account/Index.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/account/Index.vue
@@ -18,6 +18,7 @@ import AccountDelete from './components/AccountDelete.vue';
 import AutoResolve from './components/AutoResolve.vue';
 import AudioTranscription from './components/AudioTranscription.vue';
 import SectionLayout from './components/SectionLayout.vue';
+import AiSuggestions from './components/AiSuggestions.vue';
 
 export default {
   components: {
@@ -28,6 +29,7 @@ export default {
     AccountDelete,
     AutoResolve,
     AudioTranscription,
+    AiSuggestions,
     SectionLayout,
     WithLabel,
     NextInput,
@@ -244,6 +246,7 @@ export default {
     </div>
     <AutoResolve v-if="showAutoResolutionConfig" />
     <AudioTranscription v-if="showAudioTranscriptionConfig" />
+    <AiSuggestions />
     <AccountId />
     <div v-if="!uiFlags.isFetchingItem && isOnChatwootCloud">
       <AccountDelete />

--- a/app/javascript/dashboard/routes/dashboard/settings/account/components/AiSuggestions.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/account/components/AiSuggestions.vue
@@ -1,0 +1,46 @@
+<script setup>
+import { ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useAccount } from 'dashboard/composables/useAccount';
+import SectionLayout from './SectionLayout.vue';
+import Switch from 'next/switch/Switch.vue';
+import { useAlert } from 'dashboard/composables';
+
+const { t } = useI18n();
+const { currentAccount, updateAccount } = useAccount();
+const isEnabled = ref(false);
+
+watch(
+  currentAccount,
+  () => {
+    isEnabled.value = !!currentAccount.value?.settings?.ai_suggestions_enabled;
+  },
+  { immediate: true }
+);
+
+const toggle = async () => {
+  try {
+    await updateAccount(
+      { ai_suggestions_enabled: isEnabled.value },
+      { silent: true }
+    );
+    useAlert(t('GENERAL_SETTINGS.FORM.AI_SUGGESTIONS.API.SUCCESS'));
+  } catch (e) {
+    useAlert(t('GENERAL_SETTINGS.FORM.AI_SUGGESTIONS.API.ERROR'));
+  }
+};
+</script>
+
+<template>
+  <SectionLayout
+    :title="t('GENERAL_SETTINGS.FORM.AI_SUGGESTIONS.TITLE')"
+    :description="t('GENERAL_SETTINGS.FORM.AI_SUGGESTIONS.NOTE')"
+    with-border
+  >
+    <template #headerActions>
+      <div class="flex justify-end">
+        <Switch v-model="isEnabled" @change="toggle" />
+      </div>
+    </template>
+  </SectionLayout>
+</template>

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -54,7 +54,7 @@ class Account < ApplicationRecord
                  attribute_resolver: ->(record) { record.settings }
 
   store_accessor :settings, :auto_resolve_after, :auto_resolve_message, :auto_resolve_ignore_waiting
-  store_accessor :settings, :audio_transcriptions, :auto_resolve_label
+  store_accessor :settings, :audio_transcriptions, :auto_resolve_label, :ai_suggestions_enabled
 
   has_many :account_users, dependent: :destroy_async
   has_many :agent_bot_inboxes, dependent: :destroy_async

--- a/app/services/ai_reply_suggestion_service.rb
+++ b/app/services/ai_reply_suggestion_service.rb
@@ -1,0 +1,56 @@
+class AiReplySuggestionService
+  FALLBACK_MESSAGES = [
+    "I'm looking into this for you.",
+    "Thanks for your message. We'll get back to you shortly."
+  ].freeze
+
+  pattr_initialize [:conversation!]
+
+  def perform
+    return FALLBACK_MESSAGES unless feature_enabled?
+
+    body = {
+      conversation: formatted_conversation
+    }.to_json
+
+    response = HTTParty.post(api_url, headers: headers, body: body)
+    return parse_suggestions(response) if response.success?
+
+    FALLBACK_MESSAGES
+  rescue StandardError => e
+    Rails.logger.error "AI suggestion error: #{e.message}"
+    FALLBACK_MESSAGES
+  end
+
+  private
+
+  def feature_enabled?
+    ENV.fetch('AI_REPLY_SUGGESTION_ENABLED', 'false') == 'true' &&
+      api_key.present? &&
+      conversation.account.ai_suggestions_enabled
+  end
+
+  def api_key
+    ENV['AI_REPLY_SUGGESTION_API_KEY']
+  end
+
+  def api_url
+    ENV.fetch('AI_REPLY_SUGGESTION_URL', 'https://example.com/v1/suggestions')
+  end
+
+  def headers
+    {
+      'Content-Type' => 'application/json',
+      'Authorization' => "Bearer #{api_key}"
+    }
+  end
+
+  def formatted_conversation
+    LlmFormatter::LlmTextFormatterService.new(conversation).format
+  end
+
+  def parse_suggestions(response)
+    suggestions = response.parsed_response['suggestions']
+    suggestions.presence || FALLBACK_MESSAGES
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -162,6 +162,8 @@ en:
     attachment: 'Attachment'
     no_content: 'No content'
   conversations:
+    ai_suggestions:
+      error: 'AI suggestions could not be generated'
     captain:
       handoff: 'Transferring to another agent for further assistance.'
     messages:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -120,6 +120,7 @@ Rails.application.routes.draw do
               resource :participants, only: [:show, :create, :update, :destroy]
               resource :direct_uploads, only: [:create]
               resource :draft_messages, only: [:show, :update, :destroy]
+              resource :ai_suggestions, only: [:create]
             end
             member do
               post :mute


### PR DESCRIPTION
## Summary
- add service and endpoint to fetch AI reply suggestions
- expose settings toggle and chat input dropdown for suggestions
- track selected suggestion usage for analytics

## Testing
- `bundle exec rubocop app/services/ai_reply_suggestion_service.rb app/controllers/api/v1/accounts/conversations/ai_suggestions_controller.rb app/models/account.rb app/controllers/api/v1/accounts_controller.rb config/routes.rb config/locales/en.yml` *(failed: bundler: command not found: rubocop)*
- `npx eslint app/javascript/dashboard/components/ChatInputWrap.vue app/javascript/dashboard/routes/dashboard/settings/account/components/AiSuggestions.vue app/javascript/dashboard/routes/dashboard/settings/account/Index.vue`


------
https://chatgpt.com/codex/tasks/task_e_68acc5d97a2483238b2d0f13d4dae56b