### PR TITLE
feat: add message translation support

### DIFF
--- a/app/builders/messages/message_builder.rb
+++ b/app/builders/messages/message_builder.rb
@@ -18,6 +18,7 @@ class Messages::MessageBuilder
 
   def perform
     @message = @conversation.messages.build(message_params)
+    @message.content_attributes[:send_original] = @params[:send_original] if @params[:send_original]
     process_attachments
     process_emails
     @message.save!

--- a/app/controllers/api/v1/widget/base_controller.rb
+++ b/app/controllers/api/v1/widget/base_controller.rb
@@ -80,7 +80,8 @@ class Api::V1::Widget::BaseController < ApplicationController
       content: permitted_params[:message][:content],
       inbox_id: conversation.inbox_id,
       content_attributes: {
-        in_reply_to: permitted_params[:message][:reply_to]
+        in_reply_to: permitted_params[:message][:reply_to],
+        send_original: permitted_params[:message][:send_original]
       },
       echo_id: permitted_params[:message][:echo_id],
       message_type: :incoming

--- a/app/controllers/api/v1/widget/messages_controller.rb
+++ b/app/controllers/api/v1/widget/messages_controller.rb
@@ -64,7 +64,11 @@ class Api::V1::Widget::MessagesController < Api::V1::Widget::BaseController
 
   def permitted_params
     # timestamp parameter is used in create conversation method
-    params.permit(:id, :before, :after, :website_token, contact: [:name, :email], message: [:content, :referer_url, :timestamp, :echo_id, :reply_to])
+    params.permit(
+      :id, :before, :after, :website_token,
+      contact: [:name, :email],
+      message: [:content, :referer_url, :timestamp, :echo_id, :reply_to, :send_original]
+    )
   end
 
   def set_message

--- a/app/javascript/widget/api/conversation.js
+++ b/app/javascript/widget/api/conversation.js
@@ -6,8 +6,12 @@ const createConversationAPI = async content => {
   return API.post(urlData.url, urlData.params);
 };
 
-const sendMessageAPI = async (content, replyTo = null) => {
-  const urlData = endPoints.sendMessage(content, replyTo);
+const sendMessageAPI = async (
+  content,
+  replyTo = null,
+  sendOriginal = false
+) => {
+  const urlData = endPoints.sendMessage(content, replyTo, sendOriginal);
   return API.post(urlData.url, urlData.params);
 };
 

--- a/app/javascript/widget/api/endPoints.js
+++ b/app/javascript/widget/api/endPoints.js
@@ -22,7 +22,7 @@ const createConversation = params => {
   };
 };
 
-const sendMessage = (content, replyTo) => {
+const sendMessage = (content, replyTo, sendOriginal) => {
   const referrerURL = window.referrerURL || '';
   const search = buildSearchParamsWithLocale(window.location.search);
   return {
@@ -33,6 +33,7 @@ const sendMessage = (content, replyTo) => {
         reply_to: replyTo,
         timestamp: new Date().toString(),
         referer_url: referrerURL,
+        send_original: sendOriginal,
       },
     },
   };

--- a/app/javascript/widget/components/ChatFooter.vue
+++ b/app/javascript/widget/components/ChatFooter.vue
@@ -60,10 +60,11 @@ export default {
   methods: {
     ...mapActions('conversation', ['sendMessage', 'sendAttachment']),
     ...mapActions('conversationAttributes', ['getAttributes']),
-    async handleSendMessage(content) {
+    async handleSendMessage(content, { sendOriginal } = {}) {
       await this.sendMessage({
         content,
         replyTo: this.inReplyTo ? this.inReplyTo.id : null,
+        sendOriginal,
       });
       // reset replyTo message after sending
       this.inReplyTo = null;

--- a/app/javascript/widget/components/ChatInputWrap.vue
+++ b/app/javascript/widget/components/ChatInputWrap.vue
@@ -1,123 +1,109 @@
-<script>
-import { mapGetters } from 'vuex';
-
+<script setup>
+import { ref, watch, onMounted, onBeforeUnmount, computed } from 'vue';
+import { useStore } from 'vuex';
+import { useMapGetter } from 'dashboard/composables/store.js';
 import ChatAttachmentButton from 'widget/components/ChatAttachment.vue';
 import ChatSendButton from 'widget/components/ChatSendButton.vue';
-import configMixin from '../mixins/configMixin';
 import FluentIcon from 'shared/components/FluentIcon/Index.vue';
 import ResizableTextArea from 'shared/components/ResizableTextArea.vue';
-
 import EmojiInput from 'shared/components/emoji/EmojiInput.vue';
 
-export default {
-  name: 'ChatInputWrap',
-  components: {
-    ChatAttachmentButton,
-    ChatSendButton,
-    EmojiInput,
-    FluentIcon,
-    ResizableTextArea,
-  },
-  mixins: [configMixin],
-  props: {
-    onSendMessage: {
-      type: Function,
-      default: () => {},
-    },
-    onSendAttachment: {
-      type: Function,
-      default: () => {},
-    },
-  },
-  data() {
-    return {
-      userInput: '',
-      showEmojiPicker: false,
-      isFocused: false,
-    };
-  },
+const props = defineProps({
+  onSendMessage: { type: Function, default: () => {} },
+  onSendAttachment: { type: Function, default: () => {} },
+});
 
-  computed: {
-    ...mapGetters({
-      widgetColor: 'appConfig/getWidgetColor',
-      isWidgetOpen: 'appConfig/getIsWidgetOpen',
-      shouldShowFilePicker: 'appConfig/getShouldShowFilePicker',
-      shouldShowEmojiPicker: 'appConfig/getShouldShowEmojiPicker',
-    }),
-    showAttachment() {
-      return (
-        this.shouldShowFilePicker &&
-        this.hasAttachmentsEnabled &&
-        this.userInput.length === 0
-      );
-    },
-    showSendButton() {
-      return this.userInput.length > 0;
-    },
-  },
-  watch: {
-    isWidgetOpen(isWidgetOpen) {
-      if (isWidgetOpen) {
-        this.focusInput();
-      }
-    },
-  },
-  unmounted() {
-    document.removeEventListener('keypress', this.handleEnterKeyPress);
-  },
-  mounted() {
-    document.addEventListener('keypress', this.handleEnterKeyPress);
-    if (this.isWidgetOpen) {
-      this.focusInput();
-    }
-  },
+const widgetColor = useMapGetter('appConfig/getWidgetColor');
+const isWidgetOpen = useMapGetter('appConfig/getIsWidgetOpen');
+const shouldShowFilePicker = useMapGetter('appConfig/getShouldShowFilePicker');
+const shouldShowEmojiPicker = useMapGetter(
+  'appConfig/getShouldShowEmojiPicker'
+);
 
-  methods: {
-    onBlur() {
-      this.isFocused = false;
-    },
-    onFocus() {
-      this.isFocused = true;
-    },
-    handleButtonClick() {
-      if (this.userInput && this.userInput.trim()) {
-        this.onSendMessage(this.userInput);
-      }
-      this.userInput = '';
-      this.focusInput();
-    },
-    handleEnterKeyPress(e) {
-      if (e.keyCode === 13 && !e.shiftKey) {
-        e.preventDefault();
-        this.handleButtonClick();
-      }
-    },
-    toggleEmojiPicker() {
-      this.showEmojiPicker = !this.showEmojiPicker;
-    },
-    hideEmojiPicker(e) {
-      if (this.showEmojiPicker) {
-        e.stopPropagation();
-        this.toggleEmojiPicker();
-      }
-    },
-    emojiOnClick(emoji) {
-      this.userInput = `${this.userInput}${emoji} `;
-    },
-    onTypingOff() {
-      this.toggleTyping('off');
-    },
-    onTypingOn() {
-      this.toggleTyping('on');
-    },
-    toggleTyping(typingStatus) {
-      this.$store.dispatch('conversation/toggleUserTyping', { typingStatus });
-    },
-    focusInput() {
-      this.$refs.chatInput.focus();
-    },
-  },
-};
+const userInput = ref('');
+const showEmojiPicker = ref(false);
+const isFocused = ref(false);
+const chatInput = ref(null);
+
+const channelConfig = window.chatwootWebChannel;
+const hasAttachmentsEnabled = computed(() =>
+  channelConfig.enabledFeatures.includes('attachments')
+);
+const hasEmojiPickerEnabled = computed(() =>
+  channelConfig.enabledFeatures.includes('emoji_picker')
+);
+
+const showAttachment = computed(
+  () =>
+    shouldShowFilePicker.value &&
+    hasAttachmentsEnabled.value &&
+    userInput.value.length === 0
+);
+const showSendButton = computed(() => userInput.value.length > 0);
+
+const store = useStore();
+
+function focusInput() {
+  chatInput.value.focus();
+}
+function handleButtonClick(sendOriginal = false) {
+  if (userInput.value && userInput.value.trim()) {
+    props.onSendMessage(userInput.value, { sendOriginal });
+  }
+  userInput.value = '';
+  focusInput();
+}
+function handleEnterKeyPress(e) {
+  if (e.keyCode === 13 && !e.shiftKey) {
+    e.preventDefault();
+    handleButtonClick();
+  }
+}
+
+watch(isWidgetOpen, val => {
+  if (val) {
+    focusInput();
+  }
+});
+
+onMounted(() => {
+  document.addEventListener('keypress', handleEnterKeyPress);
+  if (isWidgetOpen.value) {
+    focusInput();
+  }
+});
+
+onBeforeUnmount(() => {
+  document.removeEventListener('keypress', handleEnterKeyPress);
+});
+
+function onBlur() {
+  isFocused.value = false;
+}
+function onFocus() {
+  isFocused.value = true;
+}
+function toggleEmojiPicker() {
+  showEmojiPicker.value = !showEmojiPicker.value;
+}
+function hideEmojiPicker(e) {
+  if (showEmojiPicker.value) {
+    e.stopPropagation();
+    toggleEmojiPicker();
+  }
+}
+function emojiOnClick(emoji) {
+  userInput.value = `${userInput.value}${emoji} `;
+}
+function toggleTyping(typingStatus) {
+  store.dispatch('conversation/toggleUserTyping', { typingStatus });
+}
+function onTypingOff() {
+  toggleTyping('off');
+}
+function onTypingOn() {
+  toggleTyping('on');
+}
 </script>
 
 <template>
@@ -146,7 +132,7 @@ export default {
       <ChatAttachmentButton
         v-if="showAttachment"
         class="text-n-slate-12"
-        :on-attach="onSendAttachment"
+        :on-attach="props.onSendAttachment"
       />
       <button
         v-if="shouldShowEmojiPicker && hasEmojiPickerEnabled"
@@ -172,8 +158,15 @@ export default {
       <ChatSendButton
         v-if="showSendButton"
         :color="widgetColor"
-        @click="handleButtonClick"
+        @click="handleButtonClick()"
       />
+      <button
+        v-if="showSendButton"
+        class="ml-2 text-xs text-n-slate-11"
+        @click="handleButtonClick(true)"
+      >
+        {{ $t('COMPONENTS.CHAT_INPUT.SEND_ORIGINAL') }}
+      </button>
     </div>
   </div>
 </template>

--- a/app/javascript/widget/components/ChatMessage.vue
+++ b/app/javascript/widget/components/ChatMessage.vue
@@ -1,48 +1,70 @@
-<script>
+<script setup>
+import { computed, ref } from 'vue';
+import { useStore } from 'vuex';
 import AgentMessage from 'widget/components/AgentMessage.vue';
 import UserMessage from 'widget/components/UserMessage.vue';
-import { mapGetters } from 'vuex';
 import { MESSAGE_TYPE } from 'widget/helpers/constants';
 
-export default {
-  components: {
-    AgentMessage,
-    UserMessage,
-  },
-  props: {
-    message: {
-      type: Object,
-      default: () => {},
-    },
-  },
-  computed: {
-    ...mapGetters({
-      allMessages: 'conversation/getConversation',
-    }),
-    isUserMessage() {
-      return this.message.message_type === MESSAGE_TYPE.INCOMING;
-    },
-    replyTo() {
-      const replyTo = this.message?.content_attributes?.in_reply_to;
-      return replyTo ? this.allMessages[replyTo] : null;
-    },
-  },
-};
+const props = defineProps({
+  message: { type: Object, default: () => ({}) },
+});
+
+const store = useStore();
+const allMessages = computed(
+  () => store.getters['conversation/getConversation']
+);
+const isUserMessage = computed(
+  () => props.message.message_type === MESSAGE_TYPE.INCOMING
+);
+const replyTo = computed(() => {
+  const replyId = props.message?.content_attributes?.in_reply_to;
+  return replyId ? allMessages.value[replyId] : null;
+});
+
+const showOriginal = ref(false);
+const hasOriginal = computed(
+  () => !!props.message?.content_attributes?.original_content
+);
+const displayMessage = computed(() => {
+  if (hasOriginal.value && showOriginal.value) {
+    return {
+      ...props.message,
+      content: props.message.content_attributes.original_content,
+    };
+  }
+  return props.message;
+});
+function toggleOriginal() {
+  showOriginal.value = !showOriginal.value;
+}
 </script>
 
 <template>
-  <UserMessage
-    v-if="isUserMessage"
-    :id="`cwmsg-${message.id}`"
-    :message="message"
-    :reply-to="replyTo"
-  />
-  <AgentMessage
-    v-else
-    :id="`cwmsg-${message.id}`"
-    :message="message"
-    :reply-to="replyTo"
-  />
+  <div>
+    <UserMessage
+      v-if="isUserMessage"
+      :id="`cwmsg-${message.id}`"
+      :message="displayMessage"
+      :reply-to="replyTo"
+    />
+    <AgentMessage
+      v-else
+      :id="`cwmsg-${message.id}`"
+      :message="displayMessage"
+      :reply-to="replyTo"
+    />
+    <button
+      v-if="hasOriginal"
+      class="text-xs text-n-slate-11 mt-1"
+      @click="toggleOriginal"
+    >
+      {{
+        showOriginal
+          ? $t('COMPONENTS.CHAT_MESSAGE.SHOW_TRANSLATED')
+          : $t('COMPONENTS.CHAT_MESSAGE.SHOW_ORIGINAL')
+      }}
+    </button>
+  </div>
 </template>
 
 <style scoped lang="scss">

--- a/app/javascript/widget/i18n/locale/en.json
+++ b/app/javascript/widget/i18n/locale/en.json
@@ -10,6 +10,13 @@
     "MESSAGE_BUBBLE": {
       "RETRY": "Send message again",
       "ERROR_MESSAGE": "Couldn't send, try again"
+    },
+    "CHAT_INPUT": {
+      "SEND_ORIGINAL": "Send original"
+    },
+    "CHAT_MESSAGE": {
+      "SHOW_ORIGINAL": "Show original",
+      "SHOW_TRANSLATED": "Show translated"
     }
   },
   "THUMBNAIL": {

--- a/app/javascript/widget/store/modules/conversation/actions.js
+++ b/app/javascript/widget/store/modules/conversation/actions.js
@@ -31,17 +31,17 @@ export const actions = {
     }
   },
   sendMessage: async ({ dispatch }, params) => {
-    const { content, replyTo } = params;
+    const { content, replyTo, sendOriginal } = params;
     const message = createTemporaryMessage({ content, replyTo });
-    dispatch('sendMessageWithData', message);
+    dispatch('sendMessageWithData', { ...message, sendOriginal });
   },
   sendMessageWithData: async ({ commit }, message) => {
-    const { id, content, replyTo, meta = {} } = message;
+    const { id, content, replyTo, meta = {}, sendOriginal } = message;
 
     commit('pushMessageToConversation', message);
     commit('updateMessageMeta', { id, meta: { ...meta, error: '' } });
     try {
-      const { data } = await sendMessageAPI(content, replyTo);
+      const { data } = await sendMessageAPI(content, replyTo, sendOriginal);
 
       // [VITE] Don't delete this manually, since `pushMessageToConversation` does the replacement for us anyway
       // commit('deleteMessage', message.id);

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -45,6 +45,8 @@ class Contact < ApplicationRecord
   include Labelable
   include LlmFormattable
 
+  store_accessor :additional_attributes, :preferred_language
+
   validates :account_id, presence: true
   validates :email, allow_blank: true, uniqueness: { scope: [:account_id], case_sensitive: false },
                     format: { with: Devise.email_regexp, message: I18n.t('errors.contacts.email.invalid') }

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -128,6 +128,7 @@ class Message < ApplicationRecord
   has_many :notifications, as: :primary_actor, dependent: :destroy_async
 
   after_create_commit :execute_after_create_commit_callbacks
+  after_create_commit :auto_translate
 
   after_update_commit :dispatch_update_event
 
@@ -395,6 +396,36 @@ class Message < ApplicationRecord
 
   def conversation_mail_key
     format(::Redis::Alfred::CONVERSATION_MAILER_KEY, conversation_id: conversation.id)
+  end
+
+  def auto_translate
+    return if content.blank?
+
+    service = TranslationService.new
+    contact = conversation.contact
+
+    if incoming?
+      lang = contact.preferred_language.presence || service.detect_language(content)
+      contact.update(preferred_language: lang) if contact.preferred_language.blank? && lang.present?
+      target = I18n.locale.to_s
+      translated = service.translate(content, target, source_language: lang) if lang.present? && target != lang
+      if translated.present?
+        attrs = content_attributes || {}
+        attrs['translated_content'] = translated
+        update!(content_attributes: attrs)
+      end
+    elsif outgoing?
+      return if content_attributes&.[]('send_original')
+      target = contact.preferred_language
+      translated = service.translate(content, target) if target.present?
+      if translated.present?
+        attrs = content_attributes || {}
+        attrs['original_content'] = content
+        update!(content: translated, content_attributes: attrs)
+      end
+    end
+  rescue StandardError => e
+    Rails.logger.error("translation_error: #{e.message}")
   end
 
   def validate_attachments_limit(_attachment)

--- a/app/services/translation_service.rb
+++ b/app/services/translation_service.rb
@@ -1,0 +1,53 @@
+require 'google/cloud/translate/v3'
+
+class TranslationService
+  pattr_initialize []
+
+  def detect_language(text)
+    return if text.blank? || client.blank?
+
+    response = client.detect_language(
+      content: text,
+      parent: "projects/#{project_id}"
+    )
+    response.languages.first.language_code if response&.languages&.first
+  rescue StandardError => e
+    Rails.logger.error("translation_detect_error: #{e.message}")
+    nil
+  end
+
+  def translate(text, target_language, source_language: nil)
+    return if text.blank? || target_language.blank? || client.blank?
+
+    response = client.translate_text(
+      contents: [text],
+      target_language_code: target_language,
+      parent: "projects/#{project_id}",
+      mime_type: 'text/plain',
+      source_language_code: source_language
+    )
+    response.translations.first.translated_text if response&.translations&.first
+  rescue StandardError => e
+    Rails.logger.error("translation_translate_error: #{e.message}")
+    nil
+  end
+
+  private
+
+  def project_id
+    ENV['GOOGLE_CLOUD_TRANSLATE_PROJECT_ID']
+  end
+
+  def credentials
+    ENV['GOOGLE_CLOUD_TRANSLATE_CREDENTIALS']
+  end
+
+  def client
+    return @client if defined?(@client)
+    return if credentials.blank? || project_id.blank?
+
+    @client = ::Google::Cloud::Translate::V3::TranslationService::Client.new do |config|
+      config.credentials = credentials
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add translation service and hook message auto-translations
- surface original vs translated text toggle in widget
- enable sending original or translated messages based on preference

## Testing
- `pnpm eslint`
- `pnpm test`
- `bundle exec rubocop -a` *(fails: command not found)*
- `bundle exec rspec` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acc5dfdc5483238728623e70f000b0